### PR TITLE
Update api.py _get_meters to include headers

### DIFF
--- a/src/pydukeenergy/api.py
+++ b/src/pydukeenergy/api.py
@@ -154,7 +154,9 @@ class DukeEnergy(object):
         Collecting the meter info to build meter objects.
         """
         if self._login():
-            response = self.session.get(METER_ACTIVE_URL, timeout=10)
+            headers = LOGIN_HEADERS.copy()
+            headers.update(USER_AGENT)
+            response = self.session.get(METER_ACTIVE_URL, headers=headers, timeout=10)
             _LOGGER.debug(str(response.text))
             soup = BeautifulSoup(response.text, "html.parser")
             meter_data = json.loads(soup.find("duke-dropdown", {"id": "usageAnalysisMeter"})["items"])


### PR DESCRIPTION
Hi :wave: 

Thanks for open sourcing this. I ran into an issue where the initial meters request would error out with a 403 status even when the session had cookies from a valid authentication.

I tracked it to this call and added the base headers which seemed to work.

Thanks!